### PR TITLE
Fixing The Expiry Error

### DIFF
--- a/Cookies.py
+++ b/Cookies.py
@@ -17,7 +17,9 @@ def load_cookies(driver, location, url=None):
     # have to be on a page before you can add any cookies, any page - does not matter which
     driver.get("https://google.com" if url is None else url)
     for cookie in cookies:
-        driver.add_cookie(cookie)
+    if isinstance(cookie.get('expiry'), float):#Checks if the instance expiry a float 
+        cookie['expiry'] = int(cookie['expiry'])# it converts expiry cookie to a int 
+    driver.add_cookie(cookie)
 
 
 def delete_cookies(driver, domains=None):


### PR DESCRIPTION
There was an issue when it came to expiry value being represented as a floating number when it came to the newer chrome driver versions. To resolve this problem I added an if statement that would check if expiry was an instance of a floating number and will convert it to an integer so that the driver.add_cookie(cookie) can accept it since it only accepts int values not floating values.  This is only a change in the load_cookies function since that was the one I seemed to have the only problem with.  Hopefully, this is of some help learned a lot from watching your youtube video on this.